### PR TITLE
Adjust logo vertical alignment

### DIFF
--- a/assets/icons/app-logo.svg
+++ b/assets/icons/app-logo.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="app-logo" viewBox="200 100 600 600">
           <!-- original complex logo paths, defined once -->
-          <g transform="translate(0,-48)">
+          <g transform="translate(0,-108)">
             <path
               d="
             M587.900757,611.713379 C582.531250,617.927246 576.260925,620.500854 568.486694,618.308960 C561.069336,616.217651


### PR DESCRIPTION
## Summary
- adjust the app logo's translation so that it is vertically centered within its viewBox

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0013597c88333ad32acf346425ed3