### PR TITLE
Adjust Android icon padding

### DIFF
--- a/assets/icons/app-logo.svg
+++ b/assets/icons/app-logo.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" id="app-logo" viewBox="200 100 600 600">
+<svg xmlns="http://www.w3.org/2000/svg" id="app-logo" viewBox="100 0 800 800">
           <!-- original complex logo paths, defined once -->
           <g transform="translate(0,-108)">
             <path


### PR DESCRIPTION
## Summary
- expand the app icon SVG viewbox to add additional padding so the logo renders smaller within the Android icon background

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d014a9c4608333942f73b843875fec