### PR TITLE
Ensure CSS build in Pages deployment workflow

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -31,6 +31,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build CSS
+        run: npm run build:css
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- setup Node.js and run the Tailwind build inside the GitHub Pages deployment workflow to ensure the latest CSS is published

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d01fc1acc083338d96a3297e702827