### PR TITLE
Improve mobile usability for charts and navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -681,7 +681,23 @@
               </p>
             </div>
           </div>
-          
+          <div
+            class="mt-4 flex flex-col gap-3 text-sm text-gray-600 dark:text-gray-300 sm:flex-row sm:items-center sm:justify-between"
+          >
+            <p class="text-xs sm:text-sm">
+              Tip: Drag to pan, pinch to zoom, and tap an empty area to hide the
+              tooltip.
+            </p>
+            <button
+              id="wealthChartReset"
+              type="button"
+              class="btn btn-gray text-sm self-start sm:self-auto"
+              style="padding: 0.4rem 0.75rem"
+            >
+              Reset view
+            </button>
+          </div>
+
         </div>
 
         <div class="card">


### PR DESCRIPTION
## Summary
- add tooltip helpers so the wealth forecast chart is easier to dismiss on touch devices and ensure chart containers resize with the viewport
- lock background scrolling when the mobile menu is open and surface a reset button plus usage hint beside the wealth chart

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68d01dbebd6c8333914ecf8f8e96950b