### PR TITLE
Fix mobile viewport whitespace

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
 
   <body
     class="min-h-screen flex flex-col md:flex-row bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-gray-200"
+    style="min-height: 100vh; min-height: 100dvh;"
   >
     <!-- SVG sprite: app logo + small icons -->
     <svg aria-hidden="true" width="0" height="0" style="position: absolute">
@@ -128,6 +129,7 @@
     <div
       id="sidebar"
       class="fixed inset-y-0 left-0 w-64 bg-white dark:bg-gray-800 p-6 flex flex-col items-center shadow-lg border-r border-gray-200 dark:border-gray-700 overflow-y-auto md:overflow-visible transform -translate-x-full md:relative md:translate-x-0 transition-transform duration-300 ease-in-out z-40 md:min-h-screen"
+      style="min-height: 100vh; min-height: 100dvh;"
     >
       <div class="mb-8 w-full">
         <button


### PR DESCRIPTION
## Summary
- ensure the page shell uses dynamic viewport height to avoid showing white space on tall mobile screens
- apply the same dynamic viewport height to the sidebar overlay so it always fills the screen when open

## Testing
- npm run build:css *(fails: tailwindcss CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d03a5275788333b60ef231ee46787f