### PR TITLE
Normalize card heading whitespace

### DIFF
--- a/index.html
+++ b/index.html
@@ -294,11 +294,7 @@
         </div>
 
         <div class="card">
-          <h3
-            class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2"
-          >
-            Goals
-          </h3>
+          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">Goals</h3>
           <p class="text-gray-700 dark:text-gray-300 text-sm mb-4">
             Set a wealth goal and target year to work toward.
           </p>
@@ -341,11 +337,7 @@
         </div>
 
         <div class="card transition hover:shadow-xl">
-          <h3
-            class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4"
-          >
-            Assets & Contributions
-          </h3>
+          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Assets & Contributions</h3>
           <p class="text-gray-700 dark:text-gray-300 text-sm mb-4">
             Add assets and recurring deposits, then set growth assumptions to
             project your future wealth.
@@ -529,11 +521,7 @@
         </div>
 
         <div class="card transition hover:shadow-xl">
-          <h3
-            class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4"
-          >
-            Liabilities & Payments
-          </h3>
+          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Liabilities & Payments</h3>
           <p class="text-gray-700 dark:text-gray-300 text-sm mb-4">
             Track debts or recurring expenses that reduce your wealth.
           </p>
@@ -642,9 +630,7 @@
           Forecasts
         </h2>
         <div id="forecastGoalsCard" class="card">
-          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">
-            Goal Achievement
-          </h3>
+          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Goal Achievement</h3>
           <p class="text-gray-700 dark:text-gray-300 text-sm mb-4">
             Current totals and projected goal achievement dates based on your inputs.
           </p>
@@ -652,9 +638,7 @@
             <div
               class="flex flex-col items-center justify-center p-4 rounded-lg bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100 stat-box"
             >
-              <h4 class="text-md font-medium text-gray-700 dark:text-gray-300">
-                Total Current Wealth
-              </h4>
+              <h4 class="text-md font-medium text-gray-700 dark:text-gray-300">Total Current Wealth</h4>
               <span id="totalWealthForecast" class="text-3xl font-bold -mt-4">£0</span>
             </div>
             <div id="forecastGoalsDates" class="grid grid-cols-1 md:grid-cols-3 gap-4"></div>
@@ -662,11 +646,7 @@
         </div>
         
         <div id="ForecastCard" class="card">
-          <h3
-            class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4"
-          >
-            Wealth
-          </h3>
+          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Wealth</h3>
           <p class="text-gray-700 dark:text-gray-300 text-sm">
             Click legend items to show or hide lines on the chart.
           </p>
@@ -703,11 +683,7 @@
         </div>
 
         <div class="card">
-          <h3
-            class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4"
-          >
-            One-off Events
-          </h3>
+          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">One-off Events</h3>
           <p class="text-gray-700 dark:text-gray-300 text-sm">
             Model one-off future gains or losses to see their impact on your
             forecasts.
@@ -794,11 +770,7 @@
         </div>
 
         <div id="progressCheckCard" class="card">
-          <h3
-            class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4"
-          >
-            Progress Check
-          </h3>
+          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Progress Check</h3>
           <p class="text-sm text-gray-600 dark:text-gray-300">
             Compare your current position with the forecast that was saved when
             you took a snapshot.
@@ -832,11 +804,7 @@
           </div>
         </div>
         <div id="StressTestCard" class="card">
-          <h3
-            class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4"
-          >
-            Stress Testing (Monte Carlo Simulations)
-          </h3>
+          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Stress Testing (Monte Carlo Simulations)</h3>
           <p class="text-gray-700 dark:text-gray-300 text-sm">
             Run Monte Carlo simulations with random market events (±15%) to see
             how they affect your goal timeline.
@@ -898,11 +866,7 @@
         </h2>
 
         <div class="card">
-          <h3
-            class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4"
-          >
-            Portfolio Allocation
-          </h3>
+          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Portfolio Allocation</h3>
           <div class="chart-container">
             <canvas id="assetBreakdownChart"></canvas>
             <div id="noAssetMessage" class="text-center text-gray-500">
@@ -915,11 +879,7 @@
         </div>
 
         <div id="futureValueCard" class="card">
-          <h3
-            class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4"
-          >
-            Future Asset Value
-          </h3>
+          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Future Asset Value</h3>
           <p class="text-gray-700 dark:text-gray-300 text-sm mb-4">
             Project an asset's potential value on a future date using your
             growth projections.
@@ -953,36 +913,26 @@
             <div
               class="flex flex-col items-center justify-center p-4 rounded-lg bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100 stat-box"
             >
-              <h4 class="text-md font-medium text-gray-700 dark:text-gray-300">
-                Low
-              </h4>
+              <h4 class="text-md font-medium text-gray-700 dark:text-gray-300">Low</h4>
               <span id="fvLow" class="text-3xl font-bold -mt-4">£0</span>
             </div>
             <div
               class="flex flex-col items-center justify-center p-4 rounded-lg bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100 stat-box"
             >
-              <h4 class="text-md font-medium text-gray-700 dark:text-gray-300">
-                Expected
-              </h4>
+              <h4 class="text-md font-medium text-gray-700 dark:text-gray-300">Expected</h4>
               <span id="fvExpected" class="text-3xl font-bold -mt-4">£0</span>
             </div>
             <div
               class="flex flex-col items-center justify-center p-4 rounded-lg bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100 stat-box"
             >
-              <h4 class="text-md font-medium text-gray-700 dark:text-gray-300">
-                High
-              </h4>
+              <h4 class="text-md font-medium text-gray-700 dark:text-gray-300">High</h4>
               <span id="fvHigh" class="text-3xl font-bold -mt-4">£0</span>
             </div>
           </div>
         </div>
 
         <div class="card" id="passiveIncomeCard">
-          <h3
-            class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2"
-          >
-            Estimated Passive Income
-          </h3>
+          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">Estimated Passive Income</h3>
           <p class="text-gray-700 dark:text-gray-300 text-sm mb-4">
             Based on expected annual returns and current values.
           </p>
@@ -990,17 +940,13 @@
             <div
               class="flex flex-col items-center justify-center p-4 rounded-lg bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100 stat-box"
             >
-              <h4 class="text-md font-medium text-gray-700 dark:text-gray-300">
-                Daily
-              </h4>
+              <h4 class="text-md font-medium text-gray-700 dark:text-gray-300">Daily</h4>
               <span id="passiveDaily" class="text-3xl font-bold -mt-4">£0</span>
             </div>
             <div
               class="flex flex-col items-center justify-center p-4 rounded-lg bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100 stat-box"
             >
-              <h4 class="text-md font-medium text-gray-700 dark:text-gray-300">
-                Weekly
-              </h4>
+              <h4 class="text-md font-medium text-gray-700 dark:text-gray-300">Weekly</h4>
               <span id="passiveWeekly" class="text-3xl font-bold -mt-4"
                 >£0</span
               >
@@ -1008,9 +954,7 @@
             <div
               class="flex flex-col items-center justify-center p-4 rounded-lg bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100 stat-box"
             >
-              <h4 class="text-md font-medium text-gray-700 dark:text-gray-300">
-                Monthly
-              </h4>
+              <h4 class="text-md font-medium text-gray-700 dark:text-gray-300">Monthly</h4>
               <span id="passiveMonthly" class="text-3xl font-bold -mt-4"
                 >£0</span
               >
@@ -1022,11 +966,7 @@
         </div>
 
         <div class="card" id="fireForecastCard">
-          <h3
-            class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2"
-          >
-            FIRE Readiness (Passive Income Forecast)
-          </h3>
+          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">FIRE Readiness (Passive Income Forecast)</h3>
           <p class="text-gray-700 dark:text-gray-300 text-sm mb-4">
             Project when the assets you have marked as providing passive income
             could cover your living costs under each growth scenario. The
@@ -1100,9 +1040,7 @@
         </div>
 
         <div id="inflationImpactCard" class="card is-collapsible" style="display:none;">
-          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">
-            Inflation Impact
-          </h3>
+          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Inflation Impact</h3>
           <div class="card-body">
           <p class="text-gray-700 dark:text-gray-300 text-sm mb-4">
             Enter an annual inflation rate to see the value of your goal in today's money at the point it's reached for each scenario.
@@ -1163,11 +1101,7 @@
           Snapshots
         </h2>
         <div id="saveSnapshotCard" class="card">
-          <h3
-            class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4"
-          >
-            Save Snapshot
-          </h3>
+          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Save Snapshot</h3>
           <p class="text-gray-700 dark:text-gray-300 text-sm mb-1">
             Save your current totals to track progress over time.
           </p>
@@ -1202,9 +1136,7 @@
             <h4
               id="snapshotsHeader"
               class="text-md font-medium text-gray-700 dark:text-gray-300 mb-2"
-            >
-              Saved Snapshots:
-            </h4>
+            >Saved Snapshots:</h4>
             <ul
               id="snapshotUl"
               class="divide-y divide-gray-200 dark:divide-gray-700"
@@ -1212,11 +1144,7 @@
           </div>
         </div>
         <div id="snapshotHistoryCard" class="card">
-          <h3
-            class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4"
-          >
-            Snapshot History
-          </h3>
+          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Snapshot History</h3>
           <div class="chart-container">
             <canvas id="snapshotChart"></canvas>
             <div
@@ -1261,11 +1189,7 @@
           </div>
 
           <div id="stock-profit" class="tab-content">
-            <h3
-              class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4"
-            >
-              Share Target Profit (%)
-            </h3>
+            <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Share Target Profit (%)</h3>
             <form
               id="stockProfitForm"
               class="grid grid-cols-1 md:grid-cols-2 gap-4"
@@ -1326,9 +1250,7 @@
           </div>
 
           <div id="stock-profit-amount" class="tab-content hidden">
-            <h3
-              class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4"
-            >
+            <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">
               Share Target Profit (<span data-currency-symbol>£</span>)
             </h3>
             <form
@@ -1407,11 +1329,7 @@
           </div>
 
           <div id="compound-interest" class="tab-content hidden">
-            <h3
-              class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4"
-            >
-              Compound Interest Calculator
-            </h3>
+            <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Compound Interest Calculator</h3>
             <form
               id="compoundForm"
               class="grid grid-cols-1 md:grid-cols-2 gap-4"
@@ -1485,11 +1403,7 @@
           </div>
 
           <div id="simple-interest" class="tab-content hidden">
-            <h3
-              class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4"
-            >
-              Simple Interest Calculator
-            </h3>
+            <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Simple Interest Calculator</h3>
             <form
               id="simpleInterestForm"
               class="grid grid-cols-1 md:grid-cols-2 gap-4"
@@ -1540,11 +1454,7 @@
           </div>
 
           <div id="fire-calculator" class="tab-content hidden">
-            <h3
-              class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4"
-            >
-              FIRE (Simple)
-            </h3>
+            <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">FIRE (Simple)</h3>
             <div class="mb-4 p-4 rounded-lg bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 stat-box">
               <h4 class="font-semibold mb-2">How this works</h4>
               <p class="text-sm mb-2">
@@ -1627,11 +1537,7 @@
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div id="exportCard" class="card flex flex-col">
             <div class="flex-grow">
-              <h3
-                class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4"
-              >
-                Export Your Data
-              </h3>
+              <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Export Your Data</h3>
               <p class="text-gray-700 dark:text-gray-300 text-sm mb-4">
                 Export your data with an optional password for backup or use on
                 another device.
@@ -1675,11 +1581,7 @@
 
           <div class="card flex flex-col">
             <div class="flex-grow">
-              <h3
-                class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4"
-              >
-                Import Your Data
-              </h3>
+              <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Import Your Data</h3>
               <p class="text-gray-700 dark:text-gray-300 text-sm mb-4">
                 Import previously saved data to restore your information.
               </p>
@@ -1766,11 +1668,7 @@
           Settings & Data
         </h2>
         <div class="card mb-6">
-          <h3
-            class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2"
-          >
-            Profiles
-          </h3>
+          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">Profiles</h3>
           <p class="text-gray-700 dark:text-gray-300 text-sm mb-4">
             Create and switch between profiles to keep scenarios separate.
             Assets, events, snapshots, and goals are saved per profile.
@@ -1821,11 +1719,7 @@
 
         <div id="exportCard" class="card flex flex-col">
           <div class="flex-grow">
-            <h3
-              class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4"
-            >
-              Export Your Data
-            </h3>
+            <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Export Your Data</h3>
             <p class="text-gray-700 dark:text-gray-300 text-sm mb-4">
               Export your data with an optional password for backup or use on
               another device.
@@ -1869,11 +1763,7 @@
 
         <div class="card flex flex-col">
           <div class="flex-grow">
-            <h3
-              class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4"
-            >
-              Import Your Data
-            </h3>
+            <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Import Your Data</h3>
             <p class="text-gray-700 dark:text-gray-300 text-sm mb-4">
               Import previously saved data to restore your information.
             </p>
@@ -1931,11 +1821,7 @@
         </div>
 
         <div class="card">
-          <h3
-            class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2"
-          >
-            Theme
-          </h3>
+          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">Theme</h3>
           <p class="text-gray-700 dark:text-gray-300 text-sm mb-4">
             Choose a look and feel. Your choice is saved for next time.
           </p>
@@ -1950,11 +1836,7 @@
         </div>
 
         <div id="welcomeCard" class="card">
-          <h3
-            class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2"
-          >
-            Welcome Page
-          </h3>
+          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">Welcome Page</h3>
           <p class="text-gray-700 dark:text-gray-300 text-sm mb-4">
             Show or hide the welcome page in the navigation.
           </p>
@@ -1968,11 +1850,7 @@
         </div>
 
         <div class="card">
-          <h3
-            class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2"
-          >
-            Currency
-          </h3>
+          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">Currency</h3>
           <p class="text-gray-700 dark:text-gray-300 text-sm mb-4">
             Choose the currency used throughout the app. Labels and values
             will update immediately.
@@ -1988,11 +1866,7 @@
         </div>
 
         <div class="card">
-          <h3
-            class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2"
-          >
-            Reset App
-          </h3>
+          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">Reset App</h3>
           <p class="text-gray-700 dark:text-gray-300 text-sm mb-4">
             Clear all locally stored data and restart the app.
           </p>
@@ -2036,9 +1910,7 @@
 
     <template id="tpl-snapshot-details">
       <div>
-        <h4 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-2">
-          Snapshot Details
-        </h4>
+        <h4 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-2">Snapshot Details</h4>
         <p class="text-sm text-gray-500 dark:text-gray-400 mb-4" data-date></p>
         <div class="overflow-y-auto max-h-96" data-list></div>
         <div class="mt-4 text-center">
@@ -2049,9 +1921,7 @@
 
     <template id="tpl-edit-asset">
       <div>
-        <h4 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">
-          Edit Asset
-        </h4>
+        <h4 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">Edit Asset</h4>
         <form
           id="editAssetFormModal"
           class="grid grid-cols-1 sm:grid-cols-2 gap-4"
@@ -2161,9 +2031,7 @@
 
     <template id="tpl-edit-liability">
       <div>
-        <h4 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">
-          Edit Liability
-        </h4>
+        <h4 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">Edit Liability</h4>
         <form
           id="editLiabilityFormModal"
           class="grid grid-cols-1 md:gap-4 gap-2"
@@ -2243,9 +2111,7 @@
 
     <template id="tpl-edit-event">
       <div>
-        <h4 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">
-          Edit Event
-        </h4>
+        <h4 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">Edit Event</h4>
         <form
           id="editEventForm"
           class="grid grid-cols-1 md:grid-cols-4 gap-2 md:gap-4"
@@ -2310,9 +2176,7 @@
     <!-- One-off onboarding for Assets & Goals after "Start Now" -->
     <template id="tpl-onboard-data">
       <div class="p-4 sm:p-6 max-w-full break-words">
-        <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-3">
-          Get started: Add your assets
-        </h3>
+        <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-3">Get started: Add your assets</h3>
         <p class="text-gray-700 dark:text-gray-300 mb-4">
           To build your forecast, add your assets and set a target on the
           Assets & Goals page.
@@ -2357,9 +2221,7 @@
     <!-- One-off onboarding for Forecasts when unlocked -->
     <template id="tpl-onboard-forecast">
       <div class="p-4 sm:p-6 max-w-full break-words">
-        <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-3">
-          Explore your forecast
-        </h3>
+        <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-3">Explore your forecast</h3>
         <p class="text-gray-700 dark:text-gray-300 mb-4">
           The Forecasts page projects your wealth over time using your assets, goal, and target year.
         </p>
@@ -2377,9 +2239,7 @@
     <!-- Quick tour modal -->
     <template id="tpl-quick-tour">
       <div class="p-4 sm:p-6 max-w-full break-words">
-        <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-3">
-          Quick tour (30 seconds)
-        </h3>
+        <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-3">Quick tour (30 seconds)</h3>
         <ul class="list-disc pl-5 space-y-2 text-gray-700 dark:text-gray-300 mb-4">
           <li><b>Assets & Goals</b>: add assets, set growth, and choose a target.</li>
           <li><b>Forecasts</b>: project your wealth, add one-off events.</li>


### PR DESCRIPTION
## Summary
- remove leading whitespace from card headings so titles align consistently across pages

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d31995951c833380e5ce6bb9b6f729