### PR TITLE
Trim card headings for consistent layout

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -48,6 +48,16 @@ const LS = {
 const save = (k, v) => localStorage.setItem(k, JSON.stringify(v));
 const load = (k, d) => JSON.parse(localStorage.getItem(k)) || d;
 
+function normalizeCardHeadings(root = document) {
+  root
+    .querySelectorAll(".card > h3, .card > h4")
+    .forEach((heading) => {
+      if (heading && heading.childElementCount === 0) {
+        heading.textContent = heading.textContent.trim();
+      }
+    });
+}
+
 const currencyOptions = {
   GBP: { label: "Pounds (£)", locale: "en-GB", currency: "GBP", symbol: "£" },
   USD: { label: "Dollars ($)", locale: "en-US", currency: "USD", symbol: "$" },
@@ -4430,6 +4440,9 @@ window.addEventListener("load", () => {
 
   // Enable collapsible cards
   setupCardCollapsing();
+
+  // Remove stray leading whitespace from card headings for consistent layout
+  normalizeCardHeadings();
 
   // Brand logo sizing
   sizeBrandLogo();


### PR DESCRIPTION
## Summary
- add a DOM helper that trims text content in card heading elements
- invoke the helper during initialization so card titles render without leading whitespace

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d31995951c833380e5ce6bb9b6f729