### PR TITLE
Allow forecasts without requiring a goal

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2318,7 +2318,9 @@ function updateEmptyStates() {
     goalValue > 0 ||
     goalTargetDate;
   const isFresh = !hasAnyData;
-  const canForecast = hasAssets && goalValue > 0 && goalTargetDate;
+  const hasGoal = goalValue > 0 && goalTargetDate;
+  const hasForecastInputs = hasAssets || hasLiabs;
+  const goalDrivenForecasts = hasForecastInputs && hasGoal;
 
   // Save Snapshot gating
   const snapBtn = $("snapshotBtn");
@@ -2340,15 +2342,15 @@ function updateEmptyStates() {
   // Hide full cards for brand-new users
   const ForecastCard = $("ForecastCard");
   const forecastGoalsCard = $("forecastGoalsCard");
-  if (ForecastCard) ForecastCard.hidden = !canForecast;
-  if (forecastGoalsCard) forecastGoalsCard.hidden = !canForecast;
+  if (ForecastCard) ForecastCard.hidden = !hasForecastInputs;
+  if (forecastGoalsCard) forecastGoalsCard.hidden = !goalDrivenForecasts;
   const saveSnapCard = $("saveSnapshotCard");
   if (saveSnapCard) saveSnapCard.hidden = isFresh;
   const snapHistCard = $("snapshotHistoryCard");
   if (snapHistCard) snapHistCard.hidden = snapshots.length === 0;
   const progressCard = $("progressCheckCard");
   if (progressCard)
-    progressCard.hidden = snapshots.length === 0 || !canForecast;
+    progressCard.hidden = snapshots.length === 0 || !hasForecastInputs;
   const exportCard = $("exportCard");
   if (exportCard) exportCard.hidden = isFresh;
   const futureCard = $("futureValueCard");
@@ -2361,13 +2363,13 @@ function updateEmptyStates() {
   const forecastBtn = document.querySelector('nav button[data-target="forecasts"]');
   if (forecastBtn) {
     const wasHidden = forecastBtn.classList.contains("hidden");
-    forecastBtn.classList.toggle("hidden", !canForecast);
-    if (canForecast && wasHidden) {
+    forecastBtn.classList.toggle("hidden", !hasForecastInputs);
+    if (hasForecastInputs && wasHidden) {
       forecastBtn.classList.add("fade-in");
       setTimeout(() => forecastBtn.classList.remove("fade-in"), 500);
     }
   }
-  if (!canForecast && $("forecasts").classList.contains("active")) {
+  if (!hasForecastInputs && $("forecasts").classList.contains("active")) {
     navigateTo("data-entry");
   }
 
@@ -2843,11 +2845,7 @@ function updateProgressCheckResult() {
 }
 
 function updateWealthChart() {
-  const hasData =
-    assets.length > 0 ||
-    liabilities.length > 0 ||
-    goalValue > 0 ||
-    goalTargetDate;
+  const hasData = assets.length > 0 || liabilities.length > 0;
   $("wealthChart").hidden = !hasData;
   $("wealthChartMessage").hidden = hasData;
   if (!hasData) {
@@ -3459,9 +3457,9 @@ function runStressTest(iterations, scenario, assetIds) {
 }
 
 function navigateTo(viewId) {
-  if (viewId === "forecasts" && !(assets.length > 0 && goalValue > 0 && goalTargetDate)) {
+  if (viewId === "forecasts" && !(assets.length > 0 || liabilities.length > 0)) {
     showAlert(
-      "Add at least one asset and set a wealth goal and target year to unlock Forecasts."
+      "Add at least one asset or liability to unlock Forecasts."
     );
     viewId = "data-entry";
   }

--- a/index.html
+++ b/index.html
@@ -234,7 +234,7 @@
               <h4 class="font-semibold text-gray-900 dark:text-gray-100 mb-2">Quick start</h4>
               <ul class="list-disc pl-5 text-gray-700 dark:text-gray-300">
                 <li>Create multiple profiles to keep scenarios separate (e.g., Personal, Partner, Joint, Experiments).</li>
-                <li>Add your assets and set a wealth goal and target year on the Assets & Goals page. The Forecasts tab unlocks once both are in place, and Portfolio Insights shows up after you add your first asset.</li>
+                <li>Add your assets on the Assets & Goals page. The Forecasts tab unlocks once you add an asset or liability, and Portfolio Insights shows up after you add your first asset. Set a wealth goal with a target year whenever you're ready to track goal progress.</li>
                 <li>Set expected growth rates to power projections.</li>
                 <li>Estimate future asset values from the Portfolio Insights page.</li>
                 <li>Add future one-off events to simulate gains/losses.</li>
@@ -288,8 +288,7 @@
         <div class="mb-6 p-4 rounded-lg bg-gray-100 dark:bg-gray-700 stat-box text-gray-700 dark:text-gray-300">
           <p class="text-sm">
             The data you enter here powers your projections and analysis. Add
-            assets, liabilities, and a wealth goal with a target year to drive your Forecasts and
-            Portfolio Insights.
+            assets and liabilities to drive your Forecasts and Portfolio Insights, and set a wealth goal with a target year whenever you want to track goal-specific insights.
           </p>
         </div>
 
@@ -658,8 +657,7 @@
             >
               <p class="text-lg font-medium">Your forecast will appear here.</p>
               <p>
-                Add at least one asset and set a wealth goal and target year to see your
-                financial future projected.
+                Add at least one asset or liability to see your financial future projected.
               </p>
             </div>
           </div>
@@ -2313,7 +2311,7 @@
             scenarios.
           </li>
           <li>
-            Set a wealth goal and target year to unlock Forecasts and track progress.
+            Add at least one asset or liability to unlock Forecasts, then set a wealth goal with a target year to enable goal tracking when you're ready.
           </li>
           <li>
             Choose whether each asset counts toward


### PR DESCRIPTION
## Summary
- allow the forecasts tab and wealth chart to remain available when a profile only has assets or liabilities
- keep goal-specific insights gated on goal data and refresh copy to explain the new unlock criteria

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d80a50997883339ab994a8ff929c2c