### PR TITLE
Allow forecasts to run without a goal

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2310,15 +2310,17 @@ function deleteActiveProfile() {
 function updateEmptyStates() {
   const hasAssets = assets.length > 0;
   const hasLiabs = liabilities.length > 0;
+  const hasGoalData = goalValue > 0 || goalTargetDate;
+  const hasGoal = goalValue > 0 && goalTargetDate;
+  const canForecast = hasAssets || hasLiabs;
+  const goalInsightsAvailable = canForecast && hasGoal;
   const hasAnyData =
     hasAssets ||
     hasLiabs ||
     snapshots.length > 0 ||
     simEvents.length > 0 ||
-    goalValue > 0 ||
-    goalTargetDate;
+    hasGoalData;
   const isFresh = !hasAnyData;
-  const canForecast = hasAssets && goalValue > 0 && goalTargetDate;
 
   // Save Snapshot gating
   const snapBtn = $("snapshotBtn");
@@ -2341,7 +2343,7 @@ function updateEmptyStates() {
   const ForecastCard = $("ForecastCard");
   const forecastGoalsCard = $("forecastGoalsCard");
   if (ForecastCard) ForecastCard.hidden = !canForecast;
-  if (forecastGoalsCard) forecastGoalsCard.hidden = !canForecast;
+  if (forecastGoalsCard) forecastGoalsCard.hidden = !goalInsightsAvailable;
   const saveSnapCard = $("saveSnapshotCard");
   if (saveSnapCard) saveSnapCard.hidden = isFresh;
   const snapHistCard = $("snapshotHistoryCard");
@@ -2843,11 +2845,7 @@ function updateProgressCheckResult() {
 }
 
 function updateWealthChart() {
-  const hasData =
-    assets.length > 0 ||
-    liabilities.length > 0 ||
-    goalValue > 0 ||
-    goalTargetDate;
+  const hasData = assets.length > 0 || liabilities.length > 0;
   $("wealthChart").hidden = !hasData;
   $("wealthChartMessage").hidden = hasData;
   if (!hasData) {
@@ -3077,7 +3075,7 @@ function updateWealthChart() {
 
   const wrap = $("forecastGoalsDates");
   wrap.innerHTML = "";
-  if (goalValue > 0 && assets.length > 0) {
+  if (goalValue > 0 && (assets.length > 0 || liabilities.length > 0)) {
     const getHit = (arr) => {
       for (let i = 1; i < arr.length; i++) {
         if (arr[i].y >= goalValue) return arr[i].x;
@@ -3459,9 +3457,9 @@ function runStressTest(iterations, scenario, assetIds) {
 }
 
 function navigateTo(viewId) {
-  if (viewId === "forecasts" && !(assets.length > 0 && goalValue > 0 && goalTargetDate)) {
+  if (viewId === "forecasts" && assets.length === 0 && liabilities.length === 0) {
     showAlert(
-      "Add at least one asset and set a wealth goal and target year to unlock Forecasts."
+      "Add at least one asset or liability to unlock Forecasts. Set a wealth goal to enable goal-specific insights."
     );
     viewId = "data-entry";
   }

--- a/index.html
+++ b/index.html
@@ -234,7 +234,7 @@
               <h4 class="font-semibold text-gray-900 dark:text-gray-100 mb-2">Quick start</h4>
               <ul class="list-disc pl-5 text-gray-700 dark:text-gray-300">
                 <li>Create multiple profiles to keep scenarios separate (e.g., Personal, Partner, Joint, Experiments).</li>
-                <li>Add your assets and set a wealth goal and target year on the Assets & Goals page. The Forecasts tab unlocks once both are in place, and Portfolio Insights shows up after you add your first asset.</li>
+                <li>Add your assets on the Assets & Goals page. The Forecasts tab unlocks once you have financial data, and setting a wealth goal adds goal-focused insights. Portfolio Insights shows up after you add your first asset.</li>
                 <li>Set expected growth rates to power projections.</li>
                 <li>Estimate future asset values from the Portfolio Insights page.</li>
                 <li>Add future one-off events to simulate gains/losses.</li>
@@ -658,8 +658,8 @@
             >
               <p class="text-lg font-medium">Your forecast will appear here.</p>
               <p>
-                Add at least one asset and set a wealth goal and target year to see your
-                financial future projected.
+                Add at least one asset or liability to see your financial future projected.
+                Set a wealth goal to unlock goal-focused insights.
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- allow the Forecasts view and wealth chart to display whenever assets or liabilities exist, even if no goal is configured
- keep goal-driven insights gated behind an active goal while updating UI copy to reflect the optional nature of goals

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d80a50997883339ab994a8ff929c2c