### PR TITLE
Add total current wealth card to portfolio insights

### DIFF
--- a/index.html
+++ b/index.html
@@ -866,6 +866,22 @@
         </h2>
 
         <div class="card">
+          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">
+            Total Current Wealth
+          </h3>
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-6">
+            <div
+              class="sm:col-span-1 sm:col-start-2 flex flex-col items-center justify-center gap-1 p-4 rounded-lg bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100 stat-box"
+            >
+              <h4 class="text-md font-medium text-gray-700 dark:text-gray-300">
+                Current Total
+              </h4>
+              <span id="totalWealth" class="text-3xl font-bold">£0</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="card">
           <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Portfolio Allocation</h3>
           <div class="chart-container">
             <canvas id="assetBreakdownChart"></canvas>


### PR DESCRIPTION
## Summary
- add a Total Current Wealth card to the top of the Portfolio Insights section
- reuse the existing total wealth updater so the stat box reflects current assets minus liabilities

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d8154503c483339b150b480e9fd990