### PR TITLE
Run icon generator in GitHub Pages workflow

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -38,6 +38,8 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
+      - name: Build icons
+        run: npm run build:icons
       - name: Build CSS
         run: npm run build:css
       - name: Setup Pages


### PR DESCRIPTION
## Summary
- run the icon build script as part of the GitHub Pages deployment workflow so regenerated assets are produced during CI
- keep the improved icon rasterization and PNG export settings in the generator script without committing binary outputs

## Testing
- npm run build:icons

------
https://chatgpt.com/codex/tasks/task_e_68d934d812a483339ac56bdfc6b0709e