### PR TITLE
Remove tax treatment hint text from asset table

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -858,30 +858,7 @@ function computeAssetTaxDetails() {
 function describeAssetTax(asset, summary) {
   const meta = getTaxTreatmentMeta(asset?.taxTreatment);
   if (!meta) return "";
-  if (!meta.totalsKey) {
-    return `<span class="inline-flex items-center gap-2 whitespace-nowrap">${meta.label}</span>`;
-  }
-  const band = summary?.band || getTaxBandConfig(taxSettings?.band);
-  const allowanceValue = taxSettings?.[meta.allowanceSetting] || 0;
-  const rate = band?.[meta.rateKey] || 0;
-  const details = [];
-  if (band?.label) {
-    details.push(`${band.label} ${formatPercent(rate)}`);
-  } else if (rate) {
-    details.push(formatPercent(rate));
-  }
-  if (meta.allowanceSetting) {
-    details.push(
-      `Allowance: ${fmtCurrency(allowanceValue)} ${meta.allowanceLabel}`,
-    );
-  }
-  const detailText =
-    details.length > 0
-      ? `<span class="text-xs text-gray-500 dark:text-gray-400">${details.join(
-          " · ",
-        )}</span>`
-      : "";
-  return `<span class="inline-flex items-center gap-2 whitespace-nowrap"><span>${meta.label}</span>${detailText}</span>`;
+  return `<span class="inline-flex items-center gap-2 whitespace-nowrap">${meta.label}</span>`;
 }
 
 function clearTaxCalculatorResult() {


### PR DESCRIPTION
## Summary
- simplify the tax treatment column by removing the extra hint text so only the treatment label is shown

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d9540478f08333ae8444aab4dd7224