### PR TITLE
Update first-time content toggle to control onboarding guidance

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -6005,22 +6005,29 @@ window.addEventListener("load", () => {
   if (themeSel)
     on(themeSel, "change", (e) => applyThemeChoice(e.target.value));
 
-  // Welcome page toggle
+  // First-time content toggle
   const welcomeToggle = $("welcomeToggle");
   const welcomeDisabled =
     localStorage.getItem(LS.welcomeDisabled) === "1";
   const welcomeBtn = document.querySelector(
     'nav button[data-target="welcome"]',
   );
+  const firstTimeContent = document.querySelectorAll("[data-first-time]");
   if (welcomeBtn) welcomeBtn.classList.toggle("hidden", welcomeDisabled);
+  firstTimeContent.forEach((el) =>
+    el.classList.toggle("hidden", welcomeDisabled),
+  );
   if (welcomeToggle) {
-    welcomeToggle.checked = !welcomeDisabled;
+    welcomeToggle.checked = welcomeDisabled;
     on(welcomeToggle, "change", (e) => {
-      const hide = !e.target.checked;
+      const hide = e.target.checked;
       try {
         localStorage.setItem(LS.welcomeDisabled, hide ? "1" : "0");
       } catch (_) {}
       if (welcomeBtn) welcomeBtn.classList.toggle("hidden", hide);
+      firstTimeContent.forEach((el) =>
+        el.classList.toggle("hidden", hide),
+      );
       if (hide && $("welcome").classList.contains("active"))
         navigateTo("data-entry");
     });

--- a/index.html
+++ b/index.html
@@ -285,7 +285,10 @@
         <h2 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-6">
           Assets & Goals
         </h2>
-        <div class="mb-6 p-4 rounded-lg bg-gray-100 dark:bg-gray-700 stat-box text-gray-700 dark:text-gray-300">
+        <div
+          class="mb-6 p-4 rounded-lg bg-gray-100 dark:bg-gray-700 stat-box text-gray-700 dark:text-gray-300"
+          data-first-time
+        >
           <p class="text-sm">
             The data you enter here powers your projections and analysis. Add
             assets, liabilities, and a wealth goal with a target year to drive your Forecasts and
@@ -1860,14 +1863,17 @@
         </div>
 
         <div id="welcomeCard" class="card">
-          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">Welcome Page</h3>
+          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">
+            First-Time Use Content
+          </h3>
           <div class="card-body">
             <p class="text-gray-700 dark:text-gray-300 text-sm mb-4">
-              Show or hide the welcome page in the navigation.
+              Choose whether to hide the welcome page and other first-time guidance once
+              you know your way around.
             </p>
             <label class="dark-mode-toggle">
               <span class="mr-3 font-semibold text-gray-500 dark:text-gray-400"
-                >Show Welcome Page</span
+                >Hide first-time use content</span
               >
               <input type="checkbox" id="welcomeToggle" class="peer" />
               <span class="toggle-track"><span class="toggle-thumb"></span></span>


### PR DESCRIPTION
## Summary
- rename the welcome page setting to focus on first-time use content and adjust its copy
- extend the toggle logic to hide other first-time guidance such as the Assets & Goals intro banner
- persist and apply the hide preference across sessions for both navigation and in-page helpers

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d95c1e02748333a06604af8ee3b3f3