### PR TITLE
Add future portfolio projection card and align allocation layout

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -9,7 +9,7 @@ let stressAssetIds = new Set();
 let goalValue = 0;
 let goalTargetDate = null;
 let inflationRate = 2.5;
-let wealthChart, snapshotChart, assetBreakdownChart;
+let wealthChart, snapshotChart, assetBreakdownChart, futurePortfolioChart;
 let assetForecasts = new Map();
 let liabilityForecasts = new Map();
 let lastForecastScenarios = null;
@@ -609,6 +609,7 @@ function refreshCurrencyDisplays() {
   renderLiabilities();
   renderEvents();
   renderSnapshots();
+  updateFuturePortfolioCard();
   updateInflationImpactCard();
   refreshFireProjection();
 }
@@ -684,6 +685,11 @@ const TAX_TREATMENTS = {
 };
 
 const SCENARIO_KEYS = ["low", "base", "high"];
+const SCENARIO_LABELS = {
+  low: "Low Growth",
+  base: "Expected Growth",
+  high: "High Growth",
+};
 
 function getTaxBandConfig(band) {
   return TAX_BANDS[band] || TAX_BANDS.basic;
@@ -2632,7 +2638,7 @@ function updateChartTheme() {
   if (typeof Chart !== "undefined") {
     Chart.defaults.color = tick;
   }
-  [wealthChart, snapshotChart, assetBreakdownChart].forEach((c) => {
+  [wealthChart, snapshotChart, assetBreakdownChart, futurePortfolioChart].forEach((c) => {
     if (!c) return;
     const { scales, plugins } = c.options;
     if (scales?.x) {
@@ -3427,6 +3433,8 @@ function updateEmptyStates() {
   if (exportCard) exportCard.hidden = isFresh;
   const futureCard = $("futureValueCard");
   if (futureCard) futureCard.hidden = !hasAssets;
+  const futurePortfolioCard = $("futurePortfolioCard");
+  if (futurePortfolioCard) futurePortfolioCard.hidden = !hasAssets;
   const stressTestCard = $("StressTestCard");
   if (stressTestCard) stressTestCard.hidden = !canStressTest;
   if (!canStressTest) {
@@ -4279,6 +4287,7 @@ function updateWealthChart() {
     </div>`;
   }
 
+  updateFuturePortfolioCard();
   updateInflationImpactCard();
   updateProgressCheckResult();
   refreshFireProjection();
@@ -4374,19 +4383,29 @@ function renderAssetBreakdownChart() {
   const has = assets.length > 0;
   $("assetBreakdownChart").hidden = !has;
   $("noAssetMessage").hidden = has;
+  const tableContainer = $("assetBreakdownTableContainer");
+  const tableBody = $("assetBreakdownTableBody");
   if (!has) {
     assetBreakdownChart?.destroy();
     assetBreakdownChart = null;
+    if (tableContainer) tableContainer.classList.add("hidden");
+    if (tableBody) tableBody.innerHTML = "";
     return;
   }
 
   const colorFor = (i) => `hsl(${(i * 57) % 360},70%,60%)`;
+  const rows = assets
+    .map((asset) => ({
+      name: asset.name,
+      value: calculateCurrentValue(asset),
+    }))
+    .sort((a, b) => b.value - a.value);
   const data = {
-    labels: assets.map((a) => a.name),
+    labels: rows.map((r) => r.name),
     datasets: [
       {
-        data: assets.map((asset) => calculateCurrentValue(asset)),
-        backgroundColor: assets.map((_, i) => colorFor(i)),
+        data: rows.map((r) => r.value),
+        backgroundColor: rows.map((_, i) => colorFor(i)),
       },
     ],
   };
@@ -4407,7 +4426,186 @@ function renderAssetBreakdownChart() {
     $("assetBreakdownChart").getContext("2d"),
     cfg,
   );
+  if (tableContainer && tableBody) {
+    const total = rows.reduce((sum, row) => sum + row.value, 0);
+    tableBody.innerHTML = rows
+      .map((row) => {
+        const share = total > 0 ? ((row.value / total) * 100).toFixed(2) : "0.00";
+        return `<tr class="text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700">
+      <td class="px-6 py-3 whitespace-nowrap">${row.name}</td>
+      <td class="px-6 py-3 whitespace-nowrap font-semibold">${fmtCurrency(row.value)}</td>
+      <td class="px-6 py-3 whitespace-nowrap">${share}%</td>
+    </tr>`;
+      })
+      .join("");
+    tableContainer.classList.toggle("hidden", rows.length === 0);
+  }
   updateChartTheme();
+}
+
+function updateFuturePortfolioCard({ triggeredBySubmit = false } = {}) {
+  const card = $("futurePortfolioCard");
+  if (!card) return;
+  const messageEl = $("futurePortfolioMessage");
+  const resultEl = $("futurePortfolioResult");
+  const totalEl = $("futurePortfolioTotal");
+  const noteEl = $("futurePortfolioScenarioNote");
+  const tableBody = $("futurePortfolioTableBody");
+  const tableContainer = $("futurePortfolioTableContainer");
+  const scenarioSelect = $("futurePortfolioScenario");
+  const dateInput = $("futurePortfolioDate");
+
+  const resetOutputs = (message) => {
+    if (futurePortfolioChart) {
+      futurePortfolioChart.destroy();
+      futurePortfolioChart = null;
+    }
+    if (tableBody) tableBody.innerHTML = "";
+    if (tableContainer) tableContainer.classList.add("hidden");
+    if (resultEl) resultEl.classList.add("hidden");
+    if (messageEl) {
+      if (message) messageEl.textContent = message;
+      messageEl.classList.remove("hidden");
+    }
+  };
+
+  if (!assets.length) {
+    resetOutputs(
+      "Add an asset to unlock future portfolio projections using your growth scenarios.",
+    );
+    return;
+  }
+
+  const scenarioKey = scenarioSelect?.value || "";
+  const dateStr = dateInput?.value;
+  if (!scenarioKey || !dateStr) {
+    resetOutputs(
+      "Select a growth scenario and future date to see the projected breakdown.",
+    );
+    if (triggeredBySubmit) {
+      if (!scenarioKey && scenarioSelect) scenarioSelect.focus();
+      else if (dateInput) dateInput.focus();
+    }
+    return;
+  }
+
+  const targetDate = new Date(dateStr);
+  if (Number.isNaN(targetDate.getTime())) {
+    resetOutputs("Enter a valid future date to view projected values.");
+    return;
+  }
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  targetDate.setHours(0, 0, 0, 0);
+  if (targetDate <= today) {
+    resetOutputs("Choose a future date to view projected values.");
+    if (triggeredBySubmit) {
+      dateInput.focus();
+    }
+    return;
+  }
+
+  let scenarios = lastForecastScenarios;
+  if (!scenarios || !Array.isArray(scenarios.labels)) {
+    scenarios = buildForecastScenarios(null, { includeBreakdown: true });
+  } else if (!scenarios.assetDetails) {
+    scenarios = buildForecastScenarios(null, { includeBreakdown: true });
+  }
+
+  const labels = scenarios?.labels || [];
+  const assetDetails = scenarios?.assetDetails || [];
+  if (!labels.length || !assetDetails.length) {
+    resetOutputs(
+      "Add growth assumptions to your assets to unlock projected values.",
+    );
+    return;
+  }
+
+  const index = labels.findIndex((date) => date >= targetDate);
+  if (index < 0) {
+    resetOutputs(
+      "Extend your forecast horizon (for example by updating your goal target year) to cover this date.",
+    );
+    return;
+  }
+
+  const rows = assetDetails.map((detail) => {
+    const values = detail[scenarioKey] || detail.base || [];
+    return {
+      name: detail.name || "Asset",
+      value: values[index] ?? 0,
+    };
+  });
+
+  const sortedRows = rows.sort((a, b) => b.value - a.value);
+  if (!sortedRows.length) {
+    resetOutputs("No projected asset data is available for this date.");
+    return;
+  }
+  const total = sortedRows.reduce((sum, row) => sum + row.value, 0);
+  const chartRows = sortedRows.filter((row) => row.value > 0);
+  const palette = (i) => `hsl(${(i * 57) % 360},70%,60%)`;
+
+  if (tableBody) {
+    tableBody.innerHTML = sortedRows
+      .map((row) => {
+        const share = total > 0 ? ((row.value / total) * 100).toFixed(2) : "0.00";
+        return `<tr class="text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700">
+      <td class="px-6 py-3 whitespace-nowrap">${row.name}</td>
+      <td class="px-6 py-3 whitespace-nowrap font-semibold">${fmtCurrency(row.value)}</td>
+      <td class="px-6 py-3 whitespace-nowrap">${share}%</td>
+    </tr>`;
+      })
+      .join("");
+  }
+
+  if (tableContainer) tableContainer.classList.toggle("hidden", !sortedRows.length);
+
+  if (chartRows.length === 0 && sortedRows.length) chartRows.push(sortedRows[0]);
+  if (chartRows.length) {
+    const data = {
+      labels: chartRows.map((row) => row.name),
+      datasets: [
+        {
+          data: chartRows.map((row) => row.value),
+          backgroundColor: chartRows.map((_, i) => palette(i)),
+        },
+      ],
+    };
+    const cfg = {
+      type: "pie",
+      data,
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { position: "top" },
+          tooltip: { callbacks: { label: pieTooltip } },
+        },
+      },
+    };
+    const canvas = $("futurePortfolioChart");
+    if (canvas) {
+      futurePortfolioChart = ensureChart(
+        futurePortfolioChart,
+        canvas.getContext("2d"),
+        cfg,
+      );
+      updateChartTheme();
+    }
+  }
+
+  const formattedDate = targetDate.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+  const scenarioLabel = SCENARIO_LABELS[scenarioKey] || SCENARIO_LABELS.base;
+  if (messageEl) messageEl.classList.add("hidden");
+  if (resultEl) resultEl.classList.remove("hidden");
+  if (totalEl) totalEl.textContent = fmtCurrency(total);
+  if (noteEl)
+    noteEl.textContent = `All values are projected for ${formattedDate} using your ${scenarioLabel} growth scenario.`;
 }
 
 function updateSnapshotChart() {
@@ -5179,6 +5377,10 @@ function handleFormSubmit(e) {
       buildStressHeader();
       renderStressEvents();
       setupCardCollapsing();
+      break;
+    }
+    case "futurePortfolioForm": {
+      updateFuturePortfolioCard({ triggeredBySubmit: true });
       break;
     }
     case "futureValueForm": {
@@ -6283,6 +6485,13 @@ window.addEventListener("load", () => {
   }
   const fvDate = $("fvDate");
   if (fvDate) fvDate.min = new Date().toISOString().split("T")[0];
+  const fpDate = $("futurePortfolioDate");
+  if (fpDate) {
+    fpDate.min = new Date().toISOString().split("T")[0];
+    on(fpDate, "change", () => updateFuturePortfolioCard());
+  }
+  const fpScenario = $("futurePortfolioScenario");
+  if (fpScenario) on(fpScenario, "change", () => updateFuturePortfolioCard());
   // First-run welcome routing
   const seen = localStorage.getItem(LS.welcome) === "1";
   const storedViewId = (() => {
@@ -6303,6 +6512,8 @@ window.addEventListener("load", () => {
   } else {
     navigateTo("data-entry");
   }
+
+  updateFuturePortfolioCard();
 
   async function handleAppUpdateRequest(button) {
     if (!button) return;

--- a/index.html
+++ b/index.html
@@ -785,6 +785,84 @@
 
         </div>
 
+        <div id="futurePortfolioCard" class="card">
+          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">
+            Future Portfolio
+          </h3>
+          <p class="text-gray-700 dark:text-gray-300 text-sm mb-4">
+            Select a growth scenario and future date to see how your assets could evolve based on your forecasts.
+          </p>
+          <form
+            id="futurePortfolioForm"
+            class="grid grid-cols-1 md:grid-cols-3 gap-4 items-end"
+          >
+            <div>
+              <label for="futurePortfolioScenario" class="form-label required-label"
+                >Growth Scenario</label
+              >
+              <select id="futurePortfolioScenario" class="input-field" required>
+                <option value="low">Low Growth</option>
+                <option value="base" selected>Expected Growth</option>
+                <option value="high">High Growth</option>
+              </select>
+            </div>
+            <div>
+              <label for="futurePortfolioDate" class="form-label required-label"
+                >Future Date</label
+              >
+              <input type="date" id="futurePortfolioDate" class="input-field" required />
+            </div>
+            <div class="flex md:col-span-full">
+              <button type="submit" class="btn btn-block btn-green md:mb-1">
+                View Projection
+              </button>
+            </div>
+          </form>
+          <p
+            id="futurePortfolioMessage"
+            class="mt-4 text-sm text-gray-600 dark:text-gray-300"
+          >
+            Select a growth scenario and future date to see the projected breakdown.
+          </p>
+          <div id="futurePortfolioResult" class="mt-4 hidden">
+            <div
+              class="flex flex-col items-center justify-center gap-1 p-4 mb-6 rounded-lg bg-gray-100 dark:bg-gray-700 text-center text-gray-900 dark:text-gray-100 stat-box w-full"
+            >
+              <h4 class="text-md font-medium text-gray-700 dark:text-gray-300">
+                Projected Total
+              </h4>
+              <span id="futurePortfolioTotal" class="text-3xl font-bold">£0</span>
+              <p
+                id="futurePortfolioScenarioNote"
+                class="text-xs text-gray-500 dark:text-gray-400 mt-1"
+              ></p>
+            </div>
+            <div class="chart-container">
+              <canvas id="futurePortfolioChart"></canvas>
+            </div>
+            <div
+              id="futurePortfolioTableContainer"
+              class="mt-6 overflow-x-auto hidden"
+            >
+              <table
+                class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-left"
+              >
+                <thead class="bg-gray-200 dark:bg-gray-700">
+                  <tr>
+                    <th class="table-header">Asset</th>
+                    <th class="table-header">Projected Value</th>
+                    <th class="table-header">Share</th>
+                  </tr>
+                </thead>
+                <tbody
+                  id="futurePortfolioTableBody"
+                  class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700 text-sm text-gray-700 dark:text-gray-300"
+                ></tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+
         <div id="futureValueCard" class="card">
           <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Future Asset Value</h3>
           <p class="text-gray-700 dark:text-gray-300 text-sm mb-4">
@@ -1072,6 +1150,26 @@
                 your breakdown.
               </p>
             </div>
+          </div>
+          <div
+            id="assetBreakdownTableContainer"
+            class="mt-6 overflow-x-auto hidden"
+          >
+            <table
+              class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-left"
+            >
+              <thead class="bg-gray-200 dark:bg-gray-700">
+                <tr>
+                  <th class="table-header">Asset</th>
+                  <th class="table-header">Current Value</th>
+                  <th class="table-header">Share</th>
+                </tr>
+              </thead>
+              <tbody
+                id="assetBreakdownTableBody"
+                class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700 text-sm text-gray-700 dark:text-gray-300"
+              ></tbody>
+            </table>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- add a Future Portfolio card on the forecasts page that lets users pick a growth scenario and date to see projected totals with a chart and table
- wire the new card into the existing forecasting lifecycle, gating, and form handling so results stay in sync
- extend the Portfolio Allocation card with a matching allocation table for consistency

## Testing
- npm run build:css

------
https://chatgpt.com/codex/tasks/task_e_68e0f274892483338e94d7e474bb1e82