### PR TITLE
Add snapshot comparison insights on portfolio page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1126,11 +1126,11 @@
               >Estimate as of (optional)</label
             >
             <input type="date" id="passiveIncomeDate" class="input-field" />
-            <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
-              Defaults to today. Future dates apply scheduled one-off events.
-            </p>
-          </div>
-          <div class="mb-4">
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            Defaults to today. Future dates apply scheduled one-off events.
+          </p>
+        </div>
+        <div class="mb-4">
             <label for="passiveAssetToggle" class="form-label"
               >Assets included</label
             >
@@ -1211,6 +1211,49 @@
             Excludes new contributions; shows growth from appreciation only,
             using your selected date when provided.
           </p>
+        </div>
+        <div id="snapshotComparisonCard" class="card">
+          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">
+            Snapshot Comparison
+          </h3>
+          <p class="text-gray-700 dark:text-gray-300 text-sm mb-4">
+            Review how your portfolio has changed since a saved snapshot. Compare against
+            your current assets or a snapshot captured after the one selected.
+          </p>
+          <div
+            id="snapshotComparisonEmpty"
+            class="mt-2 text-sm text-gray-500 dark:text-gray-400"
+          >
+            Take or import snapshots to unlock comparisons.
+          </div>
+          <div id="snapshotComparisonControls" class="mt-4 space-y-4 hidden">
+            <div>
+              <label for="snapshotComparisonBase" class="form-label">Base snapshot</label>
+              <select id="snapshotComparisonBase" class="input-field"></select>
+            </div>
+            <div>
+              <label for="snapshotComparisonMode" class="form-label"
+                >Compare against</label
+              >
+              <select id="snapshotComparisonMode" class="input-field">
+                <option value="current">Current portfolio</option>
+                <option value="snapshot">Another snapshot</option>
+              </select>
+            </div>
+            <div id="snapshotComparisonTargetGroup" class="hidden">
+              <label for="snapshotComparisonTarget" class="form-label"
+                >Snapshot to compare</label
+              >
+              <select id="snapshotComparisonTarget" class="input-field"></select>
+              <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                Only snapshots taken after the base selection are available.
+              </p>
+            </div>
+          </div>
+          <div
+            id="snapshotComparisonResult"
+            class="mt-4 text-sm text-gray-700 dark:text-gray-300"
+          ></div>
         </div>
       </div>
       <div id="snapshots" class="content-section">


### PR DESCRIPTION
## Summary
- add a Snapshot Comparison card to the Portfolio Insights view with controls to select base and comparison data
- compute portfolio and allocation deltas in JavaScript, including support for comparing against current assets or later snapshots
- update rendering utilities with percentage formatting and hook the new card into asset and snapshot refresh flows
- switch the comparison mode control to a select input for better mobile usability

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e13a1c38408333bae771a99781fdec