### PR TITLE
Add interest rate difference calculator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to WealthTrack will be documented in this file. This project adheres to a manual release process; update both this file and `assets/changelog.json` when shipping new versions so the in-app update summary stays accurate.
 
+## [1.1.1] - 2025-10-04
+- Add an interest rate difference calculator to compare yearly earnings between two banks.
+
 ## [1.1.0] - 2024-05-31
 - Show a changelog summary after in-app updates so users can see what's new.
 - Add repository and JSON changelog files to keep release notes in sync.

--- a/assets/changelog.json
+++ b/assets/changelog.json
@@ -1,4 +1,11 @@
-[
+[ 
+  {
+    "version": "1.1.1",
+    "date": "2025-10-04",
+    "changes": [
+      "Add an interest rate difference calculator to compare yearly earnings between two banks."
+    ]
+  },
   {
     "version": "1.1.0",
     "date": "2024-05-31",

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -5983,6 +5983,43 @@ function handleFormSubmit(e) {
       break;
     }
 
+    case "interestRateDifferenceForm": {
+      const amount = +$("interest-difference-amount").value;
+      const rateA = +$("interest-rate-a").value;
+      const rateB = +$("interest-rate-b").value;
+      const interestA = amount * (rateA / 100);
+      const interestB = amount * (rateB / 100);
+      const difference = interestB - interestA;
+      const diffAbs = Math.abs(difference);
+      const summary = (() => {
+        if (!Number.isFinite(interestA) || !Number.isFinite(interestB)) {
+          return "Enter valid numbers to compare the two rates.";
+        }
+        if (difference > 0) {
+          return `Bank B pays ${fmtCurrency(diffAbs)} more interest each year than Bank A.`;
+        }
+        if (difference < 0) {
+          return `Bank A pays ${fmtCurrency(diffAbs)} more interest each year than Bank B.`;
+        }
+        return "Both banks pay the same yearly interest.";
+      })();
+      $("interestDifferenceResult").innerHTML = `
+      <div class="rounded-lg bg-gray-100 dark:bg-gray-700 p-4 text-gray-700 dark:text-gray-200">
+        <h4 class="text-lg font-semibold mb-2">Yearly interest comparison</h4>
+        <div class="overflow-x-auto">
+          <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-left">
+            <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+              <tr><th class="px-4 py-2 font-medium">Bank A interest</th><td class="px-4 py-2">${fmtCurrency(interestA)}</td></tr>
+              <tr><th class="px-4 py-2 font-medium">Bank B interest</th><td class="px-4 py-2">${fmtCurrency(interestB)}</td></tr>
+              <tr><th class="px-4 py-2 font-medium">Difference</th><td class="px-4 py-2 font-semibold">${fmtCurrency(diffAbs)}</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-sm mt-3">${summary}</p>
+      </div>`;
+      break;
+    }
+
     case "stockProfitForm": {
       const price = +$("stock-price").value,
         tax = +$("sdrt-tax").value,

--- a/index.html
+++ b/index.html
@@ -1638,6 +1638,68 @@
 
         <div class="card">
           <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100">
+            Interest Rate Difference
+          </h3>
+          <div class="card-body">
+            <form
+              id="interestRateDifferenceForm"
+              class="grid grid-cols-1 md:grid-cols-2 gap-4"
+            >
+              <div>
+                <label
+                  for="interest-difference-amount"
+                  class="form-label required-label"
+                  >Savings balance (<span data-currency-symbol>£</span>)</label
+                >
+                <input
+                  type="number"
+                  step="any"
+                  min="0"
+                  id="interest-difference-amount"
+                  class="input-field"
+                  required
+                />
+              </div>
+              <div>
+                <label for="interest-rate-a" class="form-label required-label"
+                  >Bank A rate (%)</label
+                >
+                <input
+                  type="number"
+                  step="any"
+                  id="interest-rate-a"
+                  class="input-field"
+                  required
+                />
+              </div>
+              <div>
+                <label for="interest-rate-b" class="form-label required-label"
+                  >Bank B rate (%)</label
+                >
+                <input
+                  type="number"
+                  step="any"
+                  id="interest-rate-b"
+                  class="input-field"
+                  required
+                />
+              </div>
+              <div class="md:col-span-2 flex items-end">
+                <button type="submit" class="btn btn-block btn-green">
+                  Compare
+                </button>
+              </div>
+            </form>
+            <p class="text-xs text-gray-500 dark:text-gray-400 mt-2">
+              Calculates the yearly interest each bank would pay and shows the
+              difference down to the penny.
+            </p>
+            <div id="interestDifferenceResult" class="mt-4"></div>
+          </div>
+        </div>
+
+        <div class="card">
+          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100">
             UK Tax Impact Estimator
           </h3>
           <div class="card-body">


### PR DESCRIPTION
## Summary
- add an interest rate difference calculator card to the calculators section
- compute yearly interest comparison between two bank rates with a new form handler
- record the addition in both changelog files

## Testing
- not run (static site with no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68e148a2b5148333a7ca23ace881dfbb