### PR TITLE
Fix update dialog changelog display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to WealthTrack will be documented in this file. This project adheres to a manual release process; update both this file and `assets/changelog.json` when shipping new versions so the in-app update summary stays accurate.
 
+## [1.1.2] - 2025-10-04
+- Fix the in-app update confirmation so it reliably shows changelog details after installing a new version.
+
 ## [1.1.1] - 2025-10-04
 - Add an interest rate difference calculator to compare yearly earnings between two banks.
 

--- a/assets/changelog.json
+++ b/assets/changelog.json
@@ -1,5 +1,12 @@
 [ 
   {
+    "version": "1.1.2",
+    "date": "2025-10-04",
+    "changes": [
+      "Fix the update confirmation dialog so newly installed versions display their changelog entries."
+    ]
+  },
+  {
     "version": "1.1.1",
     "date": "2025-10-04",
     "changes": [

--- a/service-worker.js
+++ b/service-worker.js
@@ -28,8 +28,21 @@ self.addEventListener("install", (event) => {
 
 self.addEventListener("message", (event) => {
   const { data } = event || {};
-  if (data && data.type === "SKIP_WAITING") {
+  if (!data || typeof data.type !== "string") {
+    return;
+  }
+
+  if (data.type === "SKIP_WAITING") {
     self.skipWaiting();
+    return;
+  }
+
+  if (data.type === "GET_VERSION") {
+    const port = event.ports && event.ports[0] ? event.ports[0] : null;
+    const target = port || event.source;
+    if (target && typeof target.postMessage === "function") {
+      target.postMessage({ type: "VERSION", version: APP_VERSION });
+    }
   }
 });
 


### PR DESCRIPTION
## Summary
- query the active service worker for its running version before triggering an update so we can compare releases accurately
- let the service worker respond with its version when asked, enabling the update dialog to surface relevant changelog entries
- record the changelog fix in both the markdown and JSON release notes

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e150f8e8108333913da331cbcde850