### PR TITLE
Align asset deposits with end-of-period timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to WealthTrack will be documented in this file. This project adheres to a manual release process; update both this file and `assets/changelog.json` when shipping new versions so the in-app update summary stays accurate.
 
+## [1.1.12] - 2025-10-04
+- Remove the deposit day selection for assets and explain that recurring contributions are assumed to land at the end of each period.
+- Update wealth forecasts so recurring deposits are applied at the end of each period instead of being averaged across months.
+
 ## [1.1.8] - 2025-10-04
 - Fix update confirmations so newly installed versions surface the right changelog entries by tracking the service worker's version.
 - Keep the Settings version display aligned with the installed release instead of the latest download to avoid mismatched notes.

--- a/assets/changelog.json
+++ b/assets/changelog.json
@@ -1,4 +1,12 @@
-[
+[ 
+  {
+    "version": "1.1.12",
+    "date": "2025-10-04",
+    "changes": [
+      "Remove the deposit day setting for assets and clarify that contributions are applied at the end of each period.",
+      "Adjust recurring deposit calculations so forecasts add each period's contribution at the end of that period."
+    ]
+  },
   {
     "version": "1.1.10",
     "date": "2025-10-04",

--- a/index.html
+++ b/index.html
@@ -349,24 +349,9 @@
                 <option value="quarterly">Quarterly</option>
                 <option value="yearly">Yearly</option>
               </select>
-            </div>
-
-            <div class="md:col-span-full">
-              <label for="depositDay" class="form-label">
-                Deposit Day of Month
-              </label>
-              <input
-                type="number"
-                id="depositDay"
-                name="depositDay"
-                min="1"
-                max="31"
-                value="31"
-                class="input-field"
-              />
               <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                Contributions are added on this day each period. Defaults to the
-                end of the month.
+                Forecasts assume contributions are received at the end of each
+                period.
               </p>
             </div>
 
@@ -2390,18 +2375,10 @@
               <option value="quarterly">Quarterly</option>
               <option value="yearly">Yearly</option>
             </select>
-          </div>
-          <div>
-            <label for="editDepositDay" class="form-label">
-              Deposit Day of Month
-            </label>
-            <input
-              type="number"
-              min="1"
-              max="31"
-              id="editDepositDay"
-              class="input-field"
-            />
+            <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              Forecasts assume contributions are received at the end of each
+              period.
+            </p>
           </div>
           <div class="sm:col-span-2">
             <label for="editAssetStartDate" class="form-label">Start Date</label>


### PR DESCRIPTION
## Summary
- remove the asset deposit-day controls and explain that contributions land at the end of each period
- update recurring deposit calculations so forecasts and simulations add contributions at period end
- default stored deposit-day values to month end for new, imported, and exported data and refresh the changelog entries

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e17376329c8333bd4169ad2abc589b