### PR TITLE
Update interest rate comparison terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to WealthTrack will be documented in this file. This project adheres to a manual release process; update both this file and `assets/changelog.json` when shipping new versions so the in-app update summary stays accurate.
 
+## [1.1.16] - 2025-10-04
+- Rename the interest rate comparison fields to "Rate" and "Comparative rate" for clearer terminology.
+
 ## [1.1.15] - 2025-10-04
 - Content corrections.
 

--- a/assets/changelog.json
+++ b/assets/changelog.json
@@ -1,5 +1,12 @@
 [
   {
+    "version": "1.1.16",
+    "date": "2025-10-04",
+    "changes": [
+      "Rename the interest rate comparison fields to \"Rate\" and \"Comparative rate\" for clearer terminology."
+    ]
+  },
+  {
     "version": "1.1.15",
     "date": "2025-10-04",
     "changes": [

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -6339,12 +6339,12 @@ function handleFormSubmit(e) {
           return "Enter valid numbers to compare the two rates.";
         }
         if (difference > 0) {
-          return `Bank B pays ${fmtCurrency(diffAbs)} more interest each year than Bank A.`;
+          return `The comparative rate pays ${fmtCurrency(diffAbs)} more interest each year than the base rate.`;
         }
         if (difference < 0) {
-          return `Bank A pays ${fmtCurrency(diffAbs)} more interest each year than Bank B.`;
+          return `The base rate pays ${fmtCurrency(diffAbs)} more interest each year than the comparative rate.`;
         }
-        return "Both banks pay the same yearly interest.";
+        return "Both rates pay the same yearly interest.";
       })();
       $("interestDifferenceResult").innerHTML = `
       <div class="rounded-lg bg-gray-100 dark:bg-gray-700 p-4 text-gray-700 dark:text-gray-200">
@@ -6352,8 +6352,8 @@ function handleFormSubmit(e) {
         <div class="overflow-x-auto">
           <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-left">
             <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700 text-sm">
-              <tr><th class="px-4 py-2 font-medium">Bank A interest</th><td class="px-4 py-2">${fmtCurrency(interestA)}</td></tr>
-              <tr><th class="px-4 py-2 font-medium">Bank B interest</th><td class="px-4 py-2">${fmtCurrency(interestB)}</td></tr>
+              <tr><th class="px-4 py-2 font-medium">Base rate interest</th><td class="px-4 py-2">${fmtCurrency(interestA)}</td></tr>
+              <tr><th class="px-4 py-2 font-medium">Comparative rate interest</th><td class="px-4 py-2">${fmtCurrency(interestB)}</td></tr>
               <tr><th class="px-4 py-2 font-medium">Difference</th><td class="px-4 py-2 font-semibold">${fmtCurrency(diffAbs)}</td></tr>
             </tbody>
           </table>

--- a/index.html
+++ b/index.html
@@ -1666,7 +1666,7 @@
               </div>
               <div>
                 <label for="interest-rate-a" class="form-label required-label"
-                  >Bank A rate (%)</label
+                  >Rate (%)</label
                 >
                 <input
                   type="number"
@@ -1678,7 +1678,7 @@
               </div>
               <div>
                 <label for="interest-rate-b" class="form-label required-label"
-                  >Bank B rate (%)</label
+                  >Comparative rate (%)</label
                 >
                 <input
                   type="number"


### PR DESCRIPTION
## Summary
- rename the interest rate difference calculator inputs to "Rate" and "Comparative rate"
- update the result summary and table labels to use the same terminology
- record the wording update in the changelog files for version 1.1.16

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e183f54ff8833387b85b7c557a40ae