### PR TITLE
Collapse cards by default for first-time visitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to WealthTrack will be documented in this file. This project adheres to a manual release process; update both this file and `assets/changelog.json` when shipping new versions so the in-app update summary stays accurate.
 
+## [1.1.20] - 2025-10-04
+- Collapse cards by default for first-time visitors and let welcome shortcuts open their target sections immediately.
+
 ## [1.1.19] - 2025-10-04
 - Clarify that Future Portfolio forecasts include one-off Scenario Modelling events.
 

--- a/assets/changelog.json
+++ b/assets/changelog.json
@@ -1,5 +1,12 @@
 [ 
   {
+    "version": "1.1.20",
+    "date": "2025-10-04",
+    "changes": [
+      "Collapse cards by default for first-time visitors and keep welcome page shortcuts opening their target sections."
+    ]
+  },
+  {
     "version": "1.1.19",
     "date": "2025-10-04",
     "changes": [

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -78,6 +78,14 @@ const getLocalStorageItem = (key) => {
   }
 };
 
+const COLLAPSE_CARDS_BY_DEFAULT = (() => {
+  try {
+    return localStorage.getItem(LS.welcome) !== "1";
+  } catch (_) {
+    return true;
+  }
+})();
+
 const getStoredFirstTimeHidden = () => {
   try {
     return localStorage.getItem(LS.welcomeDisabled) === "1";
@@ -5367,7 +5375,8 @@ function runStressTest(iterations, scenario, assetIds) {
   };
 }
 
-function navigateTo(viewId) {
+function navigateTo(viewId, options = {}) {
+  const { expandCards = false } = options;
   if (viewId === "forecasts" && assets.length === 0 && liabilities.length === 0) {
     showAlert(
       "Add at least one asset or liability to unlock Forecasts. Set a wealth goal to enable goal-specific insights."
@@ -5401,6 +5410,9 @@ function navigateTo(viewId) {
   try {
     localStorage.setItem(LS.view, viewId);
   } catch (_) {}
+  if (expandCards) {
+    expandSectionCards(section);
+  }
   if (viewId === "portfolio-analysis") {
     renderAssetBreakdownChart();
   }
@@ -5536,7 +5548,14 @@ function setupCardCollapsing() {
       header.setAttribute("tabindex", "0");
 
       const setInitialState = () => {
-        const collapsed = localStorage.getItem(key) === "1";
+        let storedState = null;
+        try {
+          storedState = localStorage.getItem(key);
+        } catch (_) {}
+        const hasStoredPreference = storedState === "0" || storedState === "1";
+        const collapsed = hasStoredPreference
+          ? storedState === "1"
+          : COLLAPSE_CARDS_BY_DEFAULT;
         header.setAttribute("aria-expanded", collapsed ? "false" : "true");
         body.setAttribute("aria-hidden", collapsed ? "true" : "false");
         if (collapsed) {
@@ -5646,6 +5665,28 @@ function setupCardCollapsing() {
           toggle();
         }
       });
+    });
+}
+
+function expandSectionCards(section) {
+  if (!section) return;
+  section
+    .querySelectorAll(".card.is-collapsible")
+    .forEach((card) => {
+      if (!card.classList.contains("collapsed")) return;
+      const key = card.dataset.collapseKey;
+      let hasStoredPreference = false;
+      if (key) {
+        try {
+          const stored = localStorage.getItem(key);
+          hasStoredPreference = stored === "0" || stored === "1";
+        } catch (_) {}
+      }
+      if (hasStoredPreference) return;
+      const header = card.querySelector("h3, h4");
+      if (header) {
+        header.dispatchEvent(new Event("click", { bubbles: true }));
+      }
     });
 }
 
@@ -7760,12 +7801,12 @@ window.addEventListener("load", () => {
     switch (btn.dataset.action) {
       case "start-now":
         localStorage.setItem(LS.onboardPending, "1");
-        navigateTo("data-entry");
+        navigateTo("data-entry", { expandCards: true });
         break;
       case "focus-asset-form":
         {
           closeModal();
-          navigateTo("data-entry");
+          navigateTo("data-entry", { expandCards: true });
           const el = $("assetName");
           if (el) {
             try {
@@ -7780,7 +7821,7 @@ window.addEventListener("load", () => {
       case "focus-goal":
         {
           closeModal();
-          navigateTo("data-entry");
+          navigateTo("data-entry", { expandCards: true });
           const el = $("goalValue");
           if (el) {
             try {
@@ -7794,19 +7835,19 @@ window.addEventListener("load", () => {
         break;
       case "go-assets":
         closeModal();
-        navigateTo("data-entry");
+        navigateTo("data-entry", { expandCards: true });
         break;
       case "go-forecasts":
         closeModal();
-        navigateTo("forecasts");
+        navigateTo("forecasts", { expandCards: true });
         break;
       case "go-insights":
         closeModal();
-        navigateTo("portfolio-analysis");
+        navigateTo("portfolio-analysis", { expandCards: true });
         break;
       case "go-settings":
         closeModal();
-        navigateTo("settings");
+        navigateTo("settings", { expandCards: true });
         break;
       case "open-tour":
         {


### PR DESCRIPTION
## Summary
- collapse collapsible cards by default for first-time visitors while respecting stored preferences
- expand the relevant section when navigating from welcome shortcuts so guided flows surface their content
- document the behaviour change in the changelog files

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e18ecdc0dc8333a1c4a6e764c95f7f