### PR TITLE
Fix iOS install icon and sidebar logo display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to WealthTrack will be documented in this file. This project adheres to a manual release process; update both this file and `assets/changelog.json` when shipping new versions so the in-app update summary stays accurate.
 
+## [1.1.32] - 2025-10-05
+- Provide iOS with high-resolution PNG touch icons so the installed app no longer shows a blank tile.
+- Improve the sidebar logo sizing logic so the brand mark reliably appears when the menu expands on mobile Safari.
+
 ## [1.1.31] - 2025-10-05
 - Keep the passive income date picker from jumping back a day when you choose Sundays or other dates.
 

--- a/assets/changelog.json
+++ b/assets/changelog.json
@@ -1,4 +1,12 @@
 [{
+    "version": "1.1.32",
+    "date": "2025-10-05",
+    "changes": [
+      "Provide iOS with high-resolution PNG touch icons so the installed app no longer shows a blank tile.",
+      "Improve the sidebar logo sizing logic so the brand mark reliably appears when the menu expands on mobile Safari."
+    ]
+  },
+  {
     "version": "1.1.31",
     "date": "2025-10-05",
     "changes": [

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -5897,10 +5897,15 @@ function sizeBrandLogo() {
   const title = $("brandTitle");
   if (!logo || !title) return;
   try {
-    const w = title.offsetWidth || 0;
+    const rect = title.getBoundingClientRect();
+    const measuredWidth = rect && Number.isFinite(rect.width) ? rect.width : 0;
+    const w =
+      measuredWidth || title.offsetWidth || title.scrollWidth || logo.offsetWidth || 0;
     logo.style.height = "auto";
     if (w > 0) {
       logo.style.width = w + "px";
+    } else {
+      logo.style.removeProperty("width");
     }
     logo.style.marginBottom = "4px";
   } catch (_) {}

--- a/index.html
+++ b/index.html
@@ -7,7 +7,10 @@
     <meta name="theme-color" content="#111827" />
     <link rel="manifest" href="manifest.webmanifest" />
     <link rel="icon" href="assets/icons/app-logo.svg" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="assets/icons/app-logo.svg" />
+    <link rel="apple-touch-icon" sizes="180x180" href="assets/icons/icon-192.png" />
+    <link rel="apple-touch-icon" sizes="152x152" href="assets/icons/icon-192.png" />
+    <link rel="apple-touch-icon" sizes="120x120" href="assets/icons/icon-192.png" />
+    <link rel="apple-touch-icon" sizes="76x76" href="assets/icons/icon-192.png" />
 
     <!-- Inter font -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -42,7 +45,14 @@
     style="min-height: 100vh; min-height: 100dvh;"
   >
     <!-- SVG sprite: app logo + small icons -->
-    <svg aria-hidden="true" width="0" height="0" style="position: absolute">
+    <svg
+      aria-hidden="true"
+      width="0"
+      height="0"
+      style="position: absolute"
+      xmlns="http://www.w3.org/2000/svg"
+      xmlns:xlink="http://www.w3.org/1999/xlink"
+    >
       <defs>
         <symbol id="app-logo" viewBox="200 100 600 600">
           <!-- original complex logo paths, defined once -->
@@ -118,7 +128,7 @@
           class="h-10 w-10 mr-2 text-gray-800 dark:text-white -mt-2"
           fill="currentColor"
         >
-          <use href="#app-logo" />
+          <use href="#app-logo" xlink:href="#app-logo" />
         </svg>
         <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100">
           WealthTrack
@@ -143,7 +153,7 @@
             fill="currentColor"
             style="height: auto"
           >
-            <use href="#app-logo" />
+            <use href="#app-logo" xlink:href="#app-logo" />
           </svg>
           <h1
             id="brandTitle"


### PR DESCRIPTION
## Summary
- provide PNG-based apple-touch icons so the installed app shows the correct artwork on iOS
- ensure the sidebar logo renders on Safari by adding SVG namespace fallbacks and sturdier sizing logic
- document the user-facing fixes in the changelog files

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2cd4605dc8333aa0ab7aaaa256df7