### PR TITLE
Hide first-time guidance on Welcome/Export cards and simplify export copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to WealthTrack will be documented in this file. This project adheres to a manual release process; update both this file and `assets/changelog.json` when shipping new versions so the in-app update summary stays accurate.
 
+## [NEXT_VERSION] - [NEXT_DATE]
+
+- Hide first-time tips on the Welcome and Export areas when first-time guidance is turned off.
+- Rewrite the export helper text in plain language so backup and password protection are clearer for non-technical users.
+
 ## 1.1.127 - 2026-03-13
 
 - Update application software dependencies.

--- a/assets/changelog.json
+++ b/assets/changelog.json
@@ -3,7 +3,8 @@
     "version": "[NEXT_VERSION]",
     "date": "[NEXT_DATE]",
     "changes": [
-      "Update application software dependencies"
+      "Hide first-time tips on the Welcome and Export areas when first-time guidance is turned off.",
+      "Rewrite export helper text in plain language so backup and password protection are clearer for non-technical users."
     ]
   },
   {

--- a/index.html
+++ b/index.html
@@ -269,7 +269,7 @@
             </div>
           </div>
 
-          <div class="guidance-card mt-4">
+          <div class="guidance-card mt-4" data-first-time>
             <h4 class="font-semibold text-gray-900 dark:text-gray-100 mb-2">Try a demo</h4>
             <p class="text-sm text-gray-700 dark:text-gray-300 mb-3">Load sample data to explore forecasts and insights in seconds.</p>
             <button class="btn btn-purple" data-action="load-demo" aria-label="Load demo data">Load Demo Data</button>
@@ -2545,7 +2545,7 @@
               </p>
               <label class="dark-mode-toggle">
                 <span class="mr-3 font-semibold text-gray-500 dark:text-gray-400"
-                  >Show first-time use guidance</span
+                  >Show first-time guidance across the app</span
                 >
                 <input type="checkbox" id="welcomeToggle" class="peer" />
                 <span class="toggle-track"
@@ -2661,9 +2661,9 @@
             Export Data
           </h3>
           <div class="card-body flex flex-col">
-            <p class="text-gray-700 dark:text-gray-300 text-sm mb-4">
-              Export data with an optional password for backup or use on
-              another device.
+            <p class="text-gray-700 dark:text-gray-300 text-sm mb-4" data-first-time>
+              Save a backup copy of your app data to a file. Add an optional
+              password so the file contents stay private and unreadable without it.
             </p>
             <div>
               <label for="exportPassword" class="form-label"


### PR DESCRIPTION
### Motivation
- Ensure guidance items marked as "first-time" are hidden when the user disables "Show first-time guidance across the app", and make the Export helper text understandable to non-technical users.

### Description
- Mark the Welcome page "Try a demo" guidance card with `data-first-time` so it hides when first-time guidance is turned off (`index.html`).
- Mark the Export helper paragraph with `data-first-time` and replace the technical JSON wording with plain-language copy explaining backups and optional password protection (`index.html`).
- Update the settings label text to `Show first-time guidance across the app` to match requested wording (`index.html`).
- Add a `[NEXT_VERSION]` changelog entry to both `CHANGELOG.md` and `assets/changelog.json` describing the change without hardcoding a version/date.

### Testing
- Checked for dependency updates with `npm outdated` (no updates required). 
- Ran linting with `npm run lint` which completed successfully. 
- Ran unit tests with `npm test` (Jest): all test suites passed (`9 passed`, `108 tests`).
- Attempted Playwright browser installation with `npx playwright install`, which failed in this environment due to a `403 Domain forbidden` download error, so E2E tests (`npm run test:e2e`) could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc170fa7dc8333921e94538c0bee1d)