### PR TITLE
Add per-asset annual platform fee and optional fee cap for forecasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to WealthTrack will be documented in this file. This project adheres to a manual release process; update both this file and `assets/changelog.json` when shipping new versions so the in-app update summary stays accurate.
 
+## [NEXT_VERSION] - [NEXT_DATE]
+
+- Add an annual platform fee option on assets so account charges (for example ISA provider fees) are deducted from low, expected, and high growth forecasts.
+- Support optional annual fee caps per asset so provider maximum charges are respected in projections.
+
 ## 1.1.127 - 2026-03-13
 
 - Update application software dependencies.

--- a/assets/changelog.json
+++ b/assets/changelog.json
@@ -3,7 +3,8 @@
     "version": "[NEXT_VERSION]",
     "date": "[NEXT_DATE]",
     "changes": [
-      "Update application software dependencies"
+      "Add an annual platform fee option on assets so account charges (for example ISA provider fees) are deducted from low, expected, and high growth forecasts.",
+      "Support optional annual fee caps per asset so provider maximum charges are respected in projections."
     ]
   },
   {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -654,6 +654,16 @@ const SCENARIO_LABELS = {
   high: "High Growth",
 };
 
+function getAnnualAssetFeeRate(asset) {
+  if (!asset || typeof asset !== "object") return 0;
+  return toNonNegativeNumber(asset.annualFeeRate, 0);
+}
+
+function getAnnualAssetFeeCap(asset) {
+  if (!asset || typeof asset !== "object") return 0;
+  return toNonNegativeNumber(asset.annualFeeCap, 0);
+}
+
 let taxSettings = normalizeTaxSettings();
 let taxComputationCache = null;
 
@@ -718,6 +728,15 @@ function computeAssetTaxDetails() {
     SCENARIO_KEYS.forEach((scenario) => {
       const grossRate = getGrossRate(asset, scenario);
       const grossAmount = baseValue * (grossRate / 100);
+      const annualFeeRate = getAnnualAssetFeeRate(asset);
+      const annualFeeCap = getAnnualAssetFeeCap(asset);
+      const annualFeeAmountUncapped = baseValue * (annualFeeRate / 100);
+      const annualFeeAmount =
+        annualFeeCap > 0
+          ? Math.min(annualFeeAmountUncapped, annualFeeCap)
+          : annualFeeAmountUncapped;
+      const annualFeeEffectiveRate =
+        baseValue > 0 ? (annualFeeAmount / baseValue) * 100 : 0;
       let taxableAmount = 0;
       let allowanceShare = 0;
       let taxDue = 0;
@@ -733,10 +752,16 @@ function computeAssetTaxDetails() {
         netRate = baseValue > 0 ? (netAmount / baseValue) * 100 : grossRate;
         if (grossAmount > 0) effectiveTaxRate = taxDue / grossAmount;
       }
+      netRate -= annualFeeEffectiveRate;
       detail[scenario] = {
         grossRate,
         netRate,
         annualGross: grossAmount,
+        annualFeeRate,
+        annualFeeCap,
+        annualFeeAmount,
+        annualFeeAmountUncapped,
+        annualFeeEffectiveRate,
         annualTax: taxDue,
         taxableAmount,
         allowanceShare,
@@ -1422,6 +1447,8 @@ function normalizeData() {
     const ret = parseFloat(a.return) || 0;
     if (a.lowGrowth == null) a.lowGrowth = ret;
     if (a.highGrowth == null) a.highGrowth = ret;
+    a.annualFeeRate = toNonNegativeNumber(a.annualFeeRate, 0);
+    a.annualFeeCap = toNonNegativeNumber(a.annualFeeCap, 0);
     if (a.includeInPassive === undefined) a.includeInPassive = true;
     if (a.excludeNetCashflow === undefined) a.excludeNetCashflow = false;
     a.taxTreatment = normalizeTaxTreatment(a.taxTreatment);
@@ -2595,6 +2622,10 @@ function showEditAsset(index) {
   tpl.querySelector("#editAssetReturn").value = asset.return;
   tpl.querySelector("#editLowGrowth").value = asset.lowGrowth;
   tpl.querySelector("#editHighGrowth").value = asset.highGrowth;
+  const editAssetFee = tpl.querySelector("#editAssetAnnualFeeRate");
+  if (editAssetFee) editAssetFee.value = getAnnualAssetFeeRate(asset);
+  const editAssetFeeCap = tpl.querySelector("#editAssetAnnualFeeCap");
+  if (editAssetFeeCap) editAssetFeeCap.value = getAnnualAssetFeeCap(asset);
   const editTaxSelect = tpl.querySelector("#editAssetTaxTreatment");
   if (editTaxSelect)
     editTaxSelect.value = normalizeTaxTreatment(asset.taxTreatment);
@@ -2623,6 +2654,14 @@ function showEditAsset(index) {
     a.return = ret;
     a.lowGrowth = parseFloat(f.querySelector("#editLowGrowth").value) || ret;
     a.highGrowth = parseFloat(f.querySelector("#editHighGrowth").value) || ret;
+    a.annualFeeRate = toNonNegativeNumber(
+      f.querySelector("#editAssetAnnualFeeRate")?.value,
+      0,
+    );
+    a.annualFeeCap = toNonNegativeNumber(
+      f.querySelector("#editAssetAnnualFeeCap")?.value,
+      0,
+    );
     a.monthlyDeposit = monthlyFrom(a.frequency, a.originalDeposit);
     const incCbx = f.querySelector("#editIncludePassive");
     a.includeInPassive = incCbx ? !!incCbx.checked : true;
@@ -7069,6 +7108,14 @@ function handleFormSubmit(e) {
       newAsset.return = ret;
       newAsset.lowGrowth = parseFloat(form.lowGrowth.value) || ret;
       newAsset.highGrowth = parseFloat(form.highGrowth.value) || ret;
+      newAsset.annualFeeRate = toNonNegativeNumber(
+        form.assetAnnualFeeRate?.value,
+        0,
+      );
+      newAsset.annualFeeCap = toNonNegativeNumber(
+        form.assetAnnualFeeCap?.value,
+        0,
+      );
       newAsset.monthlyDeposit = monthlyFrom(
         newAsset.frequency,
         newAsset.originalDeposit,

--- a/index.html
+++ b/index.html
@@ -568,7 +568,7 @@
             </div>
 
             <div
-              class="grid grid-cols-1 md:grid-cols-3 gap-2 md:gap-4 md:col-span-full"
+              class="grid grid-cols-1 md:grid-cols-5 gap-2 md:gap-4 md:col-span-full"
             >
               <div>
                 <label for="lowGrowth" class="form-label">
@@ -616,6 +616,42 @@
                   placeholder="e.g. 4"
                   class="input-field"
                 />
+              </div>
+
+              <div>
+                <label for="assetAnnualFeeRate" class="form-label">
+                  Annual Platform Fee (%)
+                </label>
+                <input
+                  type="number"
+                  step="any"
+                  id="assetAnnualFeeRate"
+                  min="0"
+                  value="0"
+                  placeholder="e.g. 1"
+                  class="input-field"
+                />
+                <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  Optional. This annual fee is deducted from each growth scenario in forecasts.
+                </p>
+              </div>
+
+              <div>
+                <label for="assetAnnualFeeCap" class="form-label">
+                  Annual Fee Cap (<span data-currency-symbol>£</span>)
+                </label>
+                <input
+                  type="number"
+                  step="any"
+                  id="assetAnnualFeeCap"
+                  min="0"
+                  value="0"
+                  placeholder="e.g. 200"
+                  class="input-field"
+                />
+                <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  Optional. If set above 0, yearly platform charges are limited to this maximum.
+                </p>
               </div>
 
               <div>
@@ -2925,6 +2961,30 @@
               type="number"
               step="any"
               id="editAssetReturn"
+              class="input-field"
+            />
+          </div>
+          <div>
+            <label for="editAssetAnnualFeeRate" class="form-label"
+              >Annual Platform Fee (%)</label
+            >
+            <input
+              type="number"
+              step="any"
+              min="0"
+              id="editAssetAnnualFeeRate"
+              class="input-field"
+            />
+          </div>
+          <div>
+            <label for="editAssetAnnualFeeCap" class="form-label"
+              >Annual Fee Cap (<span data-currency-symbol>£</span>)</label
+            >
+            <input
+              type="number"
+              step="any"
+              min="0"
+              id="editAssetAnnualFeeCap"
               class="input-field"
             />
           </div>

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -386,6 +386,75 @@ describe('App Core Logic', () => {
     expect(assetDetails.base.netRate).toBeCloseTo(4.2, 1);
   });
 
+  test('computeAssetTaxDetails deducts annual platform fees from net growth rates', () => {
+    const now = Date.now();
+    app.setAssets([
+      {
+        name: 'ISA Platform Fee',
+        value: 50000,
+        return: 6,
+        lowGrowth: 4,
+        highGrowth: 8,
+        annualFeeRate: 1,
+        annualFeeCap: 0,
+        dateAdded: now,
+        startDate: now,
+        taxTreatment: 'tax-free'
+      }
+    ]);
+    app.setTaxSettings({
+      band: 'basic',
+      incomeAllowance: 1000,
+      dividendAllowance: 500,
+      capitalAllowance: 3000
+    });
+    app.invalidateTaxCache();
+
+    const taxDetails = app.computeAssetTaxDetails();
+    const assetDetails = taxDetails.detailMap.get(now);
+
+    expect(assetDetails.base.grossRate).toBe(6);
+    expect(assetDetails.base.annualFeeRate).toBe(1);
+    expect(assetDetails.base.annualFeeCap).toBe(0);
+    expect(assetDetails.base.annualFeeAmount).toBe(500);
+    expect(assetDetails.base.annualFeeAmountUncapped).toBe(500);
+    expect(assetDetails.base.annualFeeEffectiveRate).toBeCloseTo(1, 5);
+    expect(assetDetails.base.netRate).toBeCloseTo(5, 5);
+    expect(assetDetails.low.netRate).toBeCloseTo(3, 5);
+    expect(assetDetails.high.netRate).toBeCloseTo(7, 5);
+  });
+
+  test('computeAssetTaxDetails applies annual platform fee cap when provided', () => {
+    const now = Date.now();
+    app.setAssets([
+      {
+        name: 'Capped Fee Asset',
+        value: 50000,
+        return: 6,
+        annualFeeRate: 1,
+        annualFeeCap: 200,
+        dateAdded: now,
+        startDate: now,
+        taxTreatment: 'tax-free'
+      }
+    ]);
+    app.setTaxSettings({
+      band: 'basic',
+      incomeAllowance: 1000,
+      dividendAllowance: 500,
+      capitalAllowance: 3000
+    });
+    app.invalidateTaxCache();
+
+    const taxDetails = app.computeAssetTaxDetails();
+    const assetDetails = taxDetails.detailMap.get(now);
+
+    expect(assetDetails.base.annualFeeAmountUncapped).toBe(500);
+    expect(assetDetails.base.annualFeeAmount).toBe(200);
+    expect(assetDetails.base.annualFeeEffectiveRate).toBeCloseTo(0.4, 5);
+    expect(assetDetails.base.netRate).toBeCloseTo(5.6, 5);
+  });
+
   test('calculatePassiveAssetValueAt projects value to target date considering events and growth', () => {
     const startTs = new Date('2025-01-01').getTime();
     const asset = {


### PR DESCRIPTION
### Motivation
- Provide a way to model recurring platform/provider charges on assets so account fees are deducted from growth forecasts. 
- Allow an optional per-asset cap so provider maximum yearly charges can be respected in projections.

### Description
- Add `annualFeeRate` and `annualFeeCap` asset properties and normalize them in `normalizeData()` using `toNonNegativeNumber` in `assets/js/app.js`.
- Compute annual fee amounts and effective rates in `computeAssetTaxDetails()` and subtract the effective fee rate from the asset `netRate`, and expose fee values in the returned detail objects.
- Add helper accessors `getAnnualAssetFeeRate` and `getAnnualAssetFeeCap`, wire fee fields into the add-asset form and edit-asset modal handlers, and ensure fees persist when creating or editing assets in `assets/js/app.js` and `index.html`.
- Update UI to include `assetAnnualFeeRate` and `assetAnnualFeeCap` inputs on the add and edit asset forms in `index.html` and update changelog files `CHANGELOG.md` and `assets/changelog.json` to document the feature.
- Add unit tests in `tests/app.test.js` verifying fee deduction from net growth and correct application of a fee cap.

### Testing
- Ran the unit test suite with `npm test`, which executed the updated `tests/app.test.js` and the existing tests, and the test run completed successfully.  
- New tests validate that `computeAssetTaxDetails()` deducts annual platform fees from net growth rates and enforces the `annualFeeCap`, and both assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e28b0655f8833391f2c77578ca20c1)